### PR TITLE
Increase the gunicorn timeout

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn magma.wsgi --log-file=-
+web: gunicorn -t 60 magma.wsgi --log-file=-


### PR DESCRIPTION
Some large files are taking a while to upload. Hopefully, adjusting
the timeout on gunicorn should keep these requests from failing.
